### PR TITLE
bugfix/newresourcefilecheck

### DIFF
--- a/cmd/dr/checks.go
+++ b/cmd/dr/checks.go
@@ -36,7 +36,6 @@ var AllConfigChecks = []Check{
 // FileChecks defines the checks that are done for files on the system.
 var FileChecks = []Check{
 	NewResourceFileCheck(OneExistsOnPath([]string{"podman","docker"}), "%s was not found on your path", UpdateConfig("podman.path")),
-	//NewBinaryFileCheck("docker", "%s was not found on your path", UpdateConfigIfMissing("podman.path")),
 	NewReqConfigDirCheck("build_home"),
 	NewReqConfigDirCheck("save"),
 	NewFixableConfigFileCheck("cli-config.yaml", EmptyFileCreator),

--- a/cmd/dr/checks.go
+++ b/cmd/dr/checks.go
@@ -35,7 +35,7 @@ var AllConfigChecks = []Check{
 
 // FileChecks defines the checks that are done for files on the system.
 var FileChecks = []Check{
-	NewResourceFileCheck(OneExistsOnPath([]string{"podman","docker"}), "%s was not found on your path", UpdateConfig("podman.path")),
+	NewResourceFileCheck(OneExistsOnPath("podman","docker"), "%s was not found on your path", UpdateConfig("podman.path")),
 	NewReqConfigDirCheck("build_home"),
 	NewReqConfigDirCheck("save"),
 	NewFixableConfigFileCheck("cli-config.yaml", EmptyFileCreator),

--- a/cmd/dr/checks.go
+++ b/cmd/dr/checks.go
@@ -35,8 +35,8 @@ var AllConfigChecks = []Check{
 
 // FileChecks defines the checks that are done for files on the system.
 var FileChecks = []Check{
-	NewBinaryFileCheck("podman", "%s was not found on your path", UpdateConfig("podman.path")),
-	NewBinaryFileCheck("docker", "%s was not found on your path", UpdateConfigIfMissing("podman.path")),
+	NewResourceFileCheck(OneExistsOnPath([]string{"podman","docker"}), "%s was not found on your path", UpdateConfig("podman.path")),
+	//NewBinaryFileCheck("docker", "%s was not found on your path", UpdateConfigIfMissing("podman.path")),
 	NewReqConfigDirCheck("build_home"),
 	NewReqConfigDirCheck("save"),
 	NewFixableConfigFileCheck("cli-config.yaml", EmptyFileCreator),

--- a/cmd/dr/utils.go
+++ b/cmd/dr/utils.go
@@ -335,6 +335,9 @@ func ExistsOnPath(name string) CheckerFunc {
 	return func() (string, string, bool) {
 		found := false
 		foundPath, err := exec.LookPath(name)
+		lName := len(name)
+		lfoundPath := len(foundPath)
+		foundPath = foundPath[:lfoundPath-lName]
        if err != nil {
 		found = false
 		logger.Infof("%s...  Not found on Path", name)

--- a/cmd/dr/utils.go
+++ b/cmd/dr/utils.go
@@ -318,8 +318,7 @@ func (f *FileCheck) DoCheck(tryFix bool) (string, error) {
 
 // NewResourceFileCheck checks for any files, using the OS's PATH variable
 // automatically as the path.
-func NewResourceFileCheck(c CheckerFunc, help string, f FileAutoFixFunc) Check {	
-	
+func NewResourceFileCheck(c CheckerFunc, help string, f FileAutoFixFunc) Check {
 	return &FileCheck{
 		PathCheckFunc: 	c,
 		Path:           os.Getenv("PATH"),
@@ -334,7 +333,6 @@ func NewResourceFileCheck(c CheckerFunc, help string, f FileAutoFixFunc) Check {
 // automatically as the path.
 func ExistsOnPath(name string) CheckerFunc {
 	return func() (string, string, bool) {
-
 		found := false
 		foundPath, err := exec.LookPath(name)
        if err != nil {
@@ -344,7 +342,6 @@ func ExistsOnPath(name string) CheckerFunc {
 		found = true
 		logger.Infof("%s...  OK", foundPath)
        }
-	   
 		return foundPath, name, found
 	}
 }

--- a/cmd/dr/utils.go
+++ b/cmd/dr/utils.go
@@ -351,7 +351,7 @@ func ExistsOnPath(name string) CheckerFunc {
 
 // OneExistsOnPath checks if one of the binary files in a list exists on the path, using the OS's PATH variable
 // automatically as the path. It returns the first path that exists.
-func OneExistsOnPath(names []string) CheckerFunc {
+func OneExistsOnPath(names ...string) CheckerFunc {
 	return func() (string, string, bool) {
 		for _, name := range names {
 			if foundPath, binName, found := ExistsOnPath(name)(); found == true {

--- a/cmd/dr/utils.go
+++ b/cmd/dr/utils.go
@@ -4,19 +4,21 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/google/uuid"
-	logger "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
-	"github.com/cloud-native-toolkit/atkmod"
-	"github.com/cloud-native-toolkit/itzcli/internal/prompt"
 	"log"
 	"math/rand"
 	"net"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
+
+	"github.com/cloud-native-toolkit/atkmod"
+	"github.com/cloud-native-toolkit/itzcli/internal/prompt"
+	"github.com/google/uuid"
+	logger "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 // GetITZHomeDir returns the home directory or the ITZ command
@@ -240,11 +242,14 @@ func NewConfigCheck(configKey string, help string, defaulter DefaultGetter) Chec
 	}
 }
 
+type CheckerFunc func() (string, string, bool)
+
 type FileAutoFixFunc func(path string) (string, error)
 
 // FileCheck is a check for a required file
 type FileCheck struct {
-	Path        string
+	PathCheckFunc CheckerFunc
+	Path 		string
 	Name        string
 	IsDir       bool
 	Help        string
@@ -264,6 +269,16 @@ func (f *FileCheck) DoCheck(tryFix bool) (string, error) {
 	found := false
 	logger.Debugf("Using path: %v", f.Path)
 	foundPath := f.Path
+
+    if f.PathCheckFunc != nil {
+        if foundPath, name, found := f.PathCheckFunc(); found {
+			f.Path = foundPath
+			f.Name = name
+		} else {
+			return "", fmt.Errorf("%s not found", f.Path)
+        }
+    }
+	
 	for _, p := range strings.Split(f.Path, ":") {
 		fn := filepath.Join(p, f.Name)
 		if _, err := os.Stat(fn); errors.Is(err, os.ErrNotExist) {
@@ -301,17 +316,52 @@ func (f *FileCheck) DoCheck(tryFix bool) (string, error) {
 	return filepath.Join(foundPath, f.Name), nil
 }
 
-// NewBinaryFileCheck checks for binary files, using the OS's PATH variable
+// NewResourceFileCheck checks for any files, using the OS's PATH variable
 // automatically as the path.
-func NewBinaryFileCheck(name string, help string, f FileAutoFixFunc) Check {
+func NewResourceFileCheck(c CheckerFunc, help string, f FileAutoFixFunc) Check {	
+	
 	return &FileCheck{
-		Path:        os.Getenv("PATH"),
-		Name:        name,
-		IsDir:       false,
-		Help:        help,
-		UpdaterFunc: f,
+		PathCheckFunc: 	c,
+		Path:           os.Getenv("PATH"),
+		Name:        	"",
+		IsDir:       	false,
+		Help:        	help,
+		UpdaterFunc: 	f,
 	}
 }
+
+// ExistsOnPath checks if a binary file exists on the path, using the OS's PATH variable
+// automatically as the path.
+func ExistsOnPath(name string) CheckerFunc {
+	return func() (string, string, bool) {
+
+		found := false
+		foundPath, err := exec.LookPath(name)
+       if err != nil {
+		found = false
+		logger.Infof("%s...  Not found on Path", name)
+	   } else {
+		found = true
+		logger.Infof("%s...  OK", foundPath)
+       }
+	   
+		return foundPath, name, found
+	}
+}
+
+// OneExistsOnPath checks if one of the binary files in a list exists on the path, using the OS's PATH variable
+// automatically as the path. It returns the first path that exists.
+func OneExistsOnPath(names []string) CheckerFunc {
+	return func() (string, string, bool) {
+		for _, name := range names {
+			if foundPath, binName, found := ExistsOnPath(name)(); found == true {
+				return foundPath, binName, found
+			}
+		}
+		return "", "", false
+    }
+}
+
 
 // NewReqConfigDirCheck checks for directories inside the ITZ home directory
 func NewReqConfigDirCheck(name string) Check {

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -2,15 +2,16 @@ package test
 
 import (
 	"fmt"
-	"github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
-	"github.com/cloud-native-toolkit/itzcli/cmd/dr"
 	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/cloud-native-toolkit/itzcli/cmd/dr"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConfigCheck_DoCheck(t *testing.T) {
@@ -130,24 +131,46 @@ func TestGetITZHomeDir(t *testing.T) {
 	}
 }
 
-func TestNewBinaryFileCheck(t *testing.T) {
+func TestNewResourceFileCheck(t *testing.T) {
 	type args struct {
-		name string
+		c 	 dr.CheckerFunc
 		help string
 		f    dr.FileAutoFixFunc
 	}
+	real_c := dr.OneExistsOnPath([]string{"podman","docker"})
+	real_f := dr.UpdateConfig("podman.path")
 	tests := []struct {
 		name string
 		args args
 		want *dr.FileCheck
 	}{
-		// TODO: Add test cases.
+		{	
+			name: 		"Test if creates FileCheck object",
+			args: args{
+				c: 		real_c,
+				help:   "%s was not found on your path",
+				f: 		real_f,
+			},
+			want: &dr.FileCheck{
+				PathCheckFunc: 	real_c,
+				Path:           os.Getenv("PATH"),
+				Name:        	"",
+				IsDir:       	false,
+				Help:        	"%s was not found on your path",
+				UpdaterFunc: 	real_f,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := dr.NewBinaryFileCheck(tt.args.name, tt.args.help, tt.args.f); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewBinaryFileCheck() = %v, want %v", got, tt.want)
-			}
+			got := dr.NewResourceFileCheck(tt.args.c, tt.args.help, tt.args.f);
+			v 	:= reflect.ValueOf(got).Interface().(*dr.FileCheck)
+			wv	:= reflect.ValueOf(tt.want).Interface().(*dr.FileCheck)
+			
+			assert.Equal(t, v.Help, wv.Help, "Help is not equal")
+			assert.Equal(t, v.Path, wv.Path, "Path is not equal")
+			assert.Equal(t, v.IsDir, wv.IsDir, "IsDir is not equal")
+			assert.Equal(t, v.Name, wv.Name, "Name is not equal")
 		})
 	}
 }

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -137,7 +137,7 @@ func TestNewResourceFileCheck(t *testing.T) {
 		help string
 		f    dr.FileAutoFixFunc
 	}
-	real_c := dr.OneExistsOnPath([]string{"podman","docker"})
+	real_c := dr.OneExistsOnPath("podman","docker")
 	real_f := dr.UpdateConfig("podman.path")
 	tests := []struct {
 		name string


### PR DESCRIPTION
Changed NewBinaryFileCheck to NewResourceFileCheck and added OneExistsOnPath and ExistsOnPath as checker functions to determine path.

This is to address [issue #511](https://zenhub.ibm.com/workspaces/tech-zone-accelerator-toolkit-627a5df0f8dae200104ff923/issues/skol/ocp-installer/511)
* When I run itz doctor init on a system with Docker, the podman.path is updated to the docker binary location (full path) and there is no error from the command.
* When I run itz doctor init on a system with Podman, the podman.path is updated to the podman binary location (full path) and there is no error from the command.
* When I run itz doctor init on a system with neither Docker nor Podman, this is the only time the command returns an exit code for this check.


@nathanagood The ExistsOnPath function uses exec.LookPath(name) which returns a full path 
 (including the name) to the binary. I removed the length of the name from the path
 string, but this might not work in weird edge cases like an invisible ASCII character.