### PR TITLE
feature/resource-id

### DIFF
--- a/cmd/dr/utils.go
+++ b/cmd/dr/utils.go
@@ -192,7 +192,7 @@ func ServiceURL(scheme string, port int) DefaultGetter {
 	}
 }
 
-// Check interface for atk doctor checks
+// Check interface for itz doctor checks
 type Check interface {
 	DoCheck(tryFix bool) (string, error)
 }

--- a/cmd/listReservation.go
+++ b/cmd/listReservation.go
@@ -3,11 +3,12 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+
+	"github.com/cloud-native-toolkit/itzcli/pkg"
+	"github.com/cloud-native-toolkit/itzcli/pkg/reservations"
 	logger "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/cloud-native-toolkit/itzcli/pkg"
-	"github.com/cloud-native-toolkit/itzcli/pkg/reservations"
 )
 
 var listAllRez bool
@@ -18,7 +19,7 @@ common cause is an expired or bad API token. You can resolve this issue by going
 to https://techzone.ibm.com/my/profile to get your API token, save it in a file
 (e.g., /path/to/token.txt) and use the command:
 
-    $ atk auth login --from-file /path/to/token.txt --service reservations
+    $ itz auth login --from-file /path/to/token.txt --service reservations
 
 `
 

--- a/pkg/reservations/base.go
+++ b/pkg/reservations/base.go
@@ -2,9 +2,10 @@ package reservations
 
 import (
 	"encoding/json"
-	"github.com/cloud-native-toolkit/itzcli/pkg"
 	"io"
 	"text/template"
+
+	"github.com/cloud-native-toolkit/itzcli/pkg"
 )
 
 type ServiceLink struct {
@@ -18,7 +19,7 @@ type TZReservation struct {
 	Name           string
 	ServiceLinks   []ServiceLink
 	OpportunityId  []string
-	RequestId      string `json:"requestid"`
+	ReservationId      string `json:"id"`
 	CreatedAt      int
 	Status         string
 	ProvisionDate  string
@@ -77,7 +78,7 @@ type TextWriter struct{}
 func (w *TextWriter) Write(out io.Writer, rez TZReservation) error {
 	// TODO: Probably get this from a resource file of some kind
 	consoleTemplate := ` - {{.Name}} - {{.Status}}
-   Request Id: {{.RequestId}}
+   Reservation Id: {{.ReservationId}}
 
 `
 	tmpl, err := template.New("atkrez").Parse(consoleTemplate)

--- a/test/reservation_test.go
+++ b/test/reservation_test.go
@@ -2,11 +2,12 @@ package test
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
-	"github.com/cloud-native-toolkit/itzcli/pkg/reservations"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/cloud-native-toolkit/itzcli/pkg/reservations"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestReadReservations(t *testing.T) {
@@ -45,7 +46,7 @@ func TestFilterReadyReservations(t *testing.T) {
 	assert.NoError(t, err)
 
 	// TODO: We might want to compare this against a file.
-	assert.Equal(t, buf.String(), " - RedHat 8.4 Base Image (Fyre Advanced) - Ready\n   Request Id: 8a8bad2d-06fd-463e-8228-2450e89f8343\n\n - Redhat 8.5 Base Image with RDP (Fyre-2) - Ready\n   Request Id: 857b2bf8-cca8-4910-8fda-261229f84e90\n\n")
+	assert.Equal(t, buf.String(), " - RedHat 8.4 Base Image (Fyre Advanced) - Ready\n   Reservation Id: 6320ab2046c677001874e1be\n\n - Redhat 8.5 Base Image with RDP (Fyre-2) - Ready\n   Reservation Id: 6320b5b346c677001874e1c4\n\n")
 
 }
 


### PR DESCRIPTION
Corrected a couple instances of atk instead of itz

Changed the return value from "itz reservation list" to include the reserviation id instead of the request ID.
* The reservation id is more useful to a normal user imo and would work well with the "itz reservation get" command.
* I tested this by creating a new reservation and there is still a reservation id even during the scheduled/provisioning stage.

![image](https://user-images.githubusercontent.com/83517881/217660754-ee5bc7e4-fa1e-4195-8ab9-6f056908e1d5.png) ![image](https://user-images.githubusercontent.com/83517881/217661255-0e1a8d68-5f16-41c3-b1ed-06120f3bd5de.png)