### PR TITLE
Added deploy pipeline command to get the pipeline and run from the pipeline id

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -1,6 +1,13 @@
 package cmd
 
 import (
+	"fmt"
+
+	"github.com/cloud-native-toolkit/itzcli/pkg"
+
+	"github.com/cloud-native-toolkit/itzcli/pkg/configuration"
+	"github.com/cloud-native-toolkit/itzcli/pkg/solutions"
+	"github.com/pkg/errors"
 	logger "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -12,19 +19,96 @@ var deployCmd = &cobra.Command{
 	PreRun: SetLoggingLevel,
 }
 
-var deployBuildCmd = &cobra.Command{
-	Use:    BuildResource,
-	Short:  "Deploys the given build to the specified cluster",
-	Long:   "Deploys the given build to the specified cluster",
-	PreRun: SetLoggingLevel,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		logger.Debug("Deploying your build...")
+var deployPipelineCmd = &cobra.Command{
+	Use:   PipelineResource,
+	Short: "Deploys the given pipeline to the specified cluster",
+	Long: `
+Deploys the given pipeline to the cluster specified by --cluster-api-url ("-a").
+`,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		SetLoggingLevel(cmd, args)
+
+		if err := AssertFlag(pipelineID, NotNull, "you must specify a valid pipeline ID using --pipeline-id"); err != nil {
+			return err
+		}
+
+		if err := AssertFlag(clusterURL, ValidURL, "you must specify a valid URL using --cluster-api-url"); err != nil {
+			return err
+		}
+
+		if err := AssertFlag(clusterUsername, NotNull, "you must specify a valid username using --cluster-username"); err != nil {
+			return err
+		}
+
+		if err := AssertFlag(clusterPassword, NotNull, "you must specify a valid value using --cluster-password"); err != nil {
+			return err
+		}
+
 		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger.Debugf("Deploying your pipeline %s to cluster %s...", pipelineID, clusterURL)
+		// Go get the pipeline component from the catalog
+		apiConfig, err := LoadApiClientConfig(configuration.Backstage)
+		if err != nil {
+			return err
+		}
+		svc, err := solutions.NewWebServiceClient(apiConfig)
+		if err != nil {
+			return errors.Wrap(err, "could not create web service client")
+		}
+		sol, err := svc.Get(pipelineID)
+		if err != nil {
+			return err
+		}
+
+		// Look up the pipeline location, and get that.
+		pipelineURI, found := LookupAnnotation(sol, PipelineAnnotation)
+		if !found {
+			return fmt.Errorf("Could not find the pipeline location from catalog entry with id: %s", pipelineID)
+		}
+
+		pipelineRunURI, found := LookupAnnotation(sol, PipelineRunAnnotation)
+		if !found {
+			// try guesssing...
+			logger.Infof("No pipeline run location was found, attempting to guess...")
+			pipelineRunURI, err = pkg.AppendToFilename(pipelineURI, "-run")
+			if err != nil {
+				return nil
+			}
+			logger.Debugf("Guessed %s as the pipeline run location.", pipelineRunURI)
+		}
+
+		execArgs := PipelineExecArgs{
+			PipelineURI:     pipelineURI,
+			PipelineRunURI:  pipelineRunURI,
+			ClusterURL:      clusterURL,
+			ClusterUsername: clusterUsername,
+			ClusterPassword: clusterPassword,
+			AdditionalArgs:  args,
+			AcceptDefaults:  acceptDefaults,
+			UseContainer:    useContainer,
+		}
+		return ExecutePipeline(cmd, execArgs)
 	},
 }
 
+func LookupAnnotation(sol *solutions.Solution, name string) (string, bool) {
+	if sol.Entity.Metadata.Annotations != nil && len(sol.Entity.Metadata.Annotations) > 0 {
+		val, found := sol.Entity.Metadata.Annotations[name]
+		return val, found
+	}
+	return "", false
+}
+
 func init() {
-	deployCmd.AddCommand(deployBuildCmd)
+	deployPipelineCmd.Flags().StringVarP(&pipelineID, "pipeline-id", "p", "", "ID of the build in the catalog")
+	deployPipelineCmd.Flags().StringVarP(&clusterURL, "cluster-api-url", "a", "", "The URL of the target cluster")
+	deployPipelineCmd.Flags().StringVarP(&clusterUsername, "cluster-username", "u", "", "A username to login to the target cluster")
+	deployPipelineCmd.Flags().StringVarP(&clusterPassword, "cluster-password", "P", "", "A password to login to the target cluster")
+	deployPipelineCmd.Flags().BoolVarP(&acceptDefaults, "accept-defaults", "d", false, "Accept defaults for pipeline parameters without asking")
+	deployPipelineCmd.Flags().BoolVarP(&useContainer, "use-container", "c", DefaultUseContainer, "If true, the commands run in a container")
+	deployCmd.AddCommand(deployPipelineCmd)
 
 	rootCmd.AddCommand(deployCmd)
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -24,6 +24,21 @@ var deployPipelineCmd = &cobra.Command{
 	Short: "Deploys the given pipeline to the specified cluster",
 	Long: `
 Deploys the given pipeline to the cluster specified by --cluster-api-url ("-a").
+The pipeline is identified by a UUID and can be found by executing the command:
+
+    itz list pipelines
+
+To view the current pipelines. With the pipeline ID, you can deploy the pipeline
+to a cluster with the given API endpoint ("--cluster-api-url" or "-a"), and a 
+username/password of a user with permissions to create Pipelines and PipelineRuns.
+
+Example:
+
+    itz deploy pipeline -p c567d9bd-5f0f-4254-bce1-c40ef1fedc0c \
+      -a http://cluster.api.example.com \
+      -u clusteruser \
+      -P mysecretpassword
+
 `,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		SetLoggingLevel(cmd, args)

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -205,7 +205,15 @@ func ExecutePipeline(cmd *cobra.Command, execArgs PipelineExecArgs) error {
 	client := &pkg.GitServiceClient{
 		BaseDest: "/tmp",
 	}
-	pipeline, err := client.Get(execArgs.PipelineURI, pkg.UnmarshalPipeline)
+
+	rawPipelineURL, err := pkg.MapGitUrlToRaw(execArgs.PipelineURI)
+	if err != nil {
+		return err
+	}
+	pipeline, err := client.Get(rawPipelineURL, pkg.UnmarshalPipeline)
+	if err != nil {
+		return err
+	}
 	pl := pipeline.(*v1beta1.Pipeline)
 	if err != nil {
 		return fmt.Errorf("error trying to get pipeline at \"%s\": %v", execArgs.PipelineURI, err)
@@ -257,7 +265,11 @@ func ExecutePipeline(cmd *cobra.Command, execArgs PipelineExecArgs) error {
 	// answers
 	chainedResolver.AddResolver(promptResolver)
 
-	pRun, err := client.Get(execArgs.PipelineRunURI, pkg.UnmarshalPipelineRun)
+	rawPipelineRunURL, err := pkg.MapGitUrlToRaw(execArgs.PipelineRunURI)
+	if err != nil {
+		return err
+	}
+	pRun, err := client.Get(rawPipelineRunURL, pkg.UnmarshalPipelineRun)
 	if err != nil {
 		return err
 	}

--- a/cmd/names.go
+++ b/cmd/names.go
@@ -19,3 +19,6 @@ const WorkspaceResource = "workspace"
 
 const TechZoneFull = "IBM Technology Zone"
 const TechZoneShort = "TechZone"
+
+const PipelineAnnotation = "techzone.ibm.com/tekton-pipeline-location"
+const PipelineRunAnnotation = "techzone.ibm.com/tekton-pipeline-run-location"

--- a/pkg/fileutils.go
+++ b/pkg/fileutils.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -29,6 +30,21 @@ func MustITZHomeDir() string {
 		logger.Fatal(err)
 	}
 	return home
+}
+
+// AppendToFilename appends the suffix to the name of the file. The file is expected
+// to be a URL
+func AppendToFilename(fn string, suffix string) (string, error) {
+	u, err := url.Parse(fn)
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Dir(u.Path)
+	base := filepath.Base(u.Path)
+	baseParts := strings.Split(base, ".")
+	ext := filepath.Ext(u.Path)
+	u.Path = fmt.Sprintf("%s/%s%s%s", dir, strings.Join(baseParts[:len(baseParts)-1], "."), suffix, ext)
+	return u.String(), nil
 }
 
 // ReadFile reads the given file into the byte array

--- a/pkg/solutions/base.go
+++ b/pkg/solutions/base.go
@@ -31,6 +31,16 @@ func KindFilter(kind []string) FilterOptions {
 	}
 }
 
+func TypeFilter(t []string) FilterOptions {
+	return func(f *Filter) {
+		if len(t) == 0 {
+			return
+		}
+		filterString := fmt.Sprintf("spec.type=%s", strings.Join(t, ",spec.type="))
+		f.Filter = append(f.Filter, filterString)
+	}
+}
+
 func NewFilter(options ...FilterOptions) *Filter {
 	filter := &Filter{}
 

--- a/test/fileutils_test.go
+++ b/test/fileutils_test.go
@@ -1,0 +1,50 @@
+package test
+
+import (
+	"github.com/cloud-native-toolkit/itzcli/pkg"
+	"testing"
+)
+
+func TestAppendToFilename(t *testing.T) {
+	type args struct {
+		fn     string
+		suffix string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "normal happy path replacement",
+			args: args{
+				fn:     "https://github.com/cloud-native-toolkit/deployer-operator-masauto/blob/main/maximo-pipeline.yaml",
+				suffix: "-run",
+			},
+			want:    "https://github.com/cloud-native-toolkit/deployer-operator-masauto/blob/main/maximo-pipeline-run.yaml",
+			wantErr: false,
+		},
+		{
+			name: "normal happy path replacement - file scheme",
+			args: args{
+				fn:     "file:///home/user1/cloud-native-toolkit/deployer-operator-masauto/blob/main/maximo-pipeline.yaml",
+				suffix: "-run",
+			},
+			want:    "file:///home/user1/cloud-native-toolkit/deployer-operator-masauto/blob/main/maximo-pipeline-run.yaml",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := pkg.AppendToFilename(tt.args.fn, tt.args.suffix)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AppendToFilename() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("AppendToFilename() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implemented the command `deploy pipeline` to directly deploy the pipeline, given the pipeline ID. Also cleaned up the `list pipelines` command to query for only the `pipeline` type, as described in the catalog. 

For example, see:

```bash
$ itz list pipelines
NAME                                                                ID                                    NAMESPACE
Some pipeline 09f581a8-c4f1-47e0-b66f-41e4795c1ad5 default
```

So, to deploy this pipeline to a cluster, you can use the command:

```bash
$ itz deploy pipeline -a https://my.cluster.example.com:6443 -u clusterusr -P mysecretclusterpassword -p 09f581a8-c4f1-47e0-b66f-41e4795c1ad5
```



Signed-off-by: Nathan Good <nathan.good@ibm.com>
